### PR TITLE
Add line feed to the last line

### DIFF
--- a/lib/core/exporter.ex
+++ b/lib/core/exporter.ex
@@ -11,7 +11,8 @@ defmodule TelemetryMetricsPrometheus.Core.Exporter do
       end
     end)
     |> Enum.reject(&is_nil/1)
-    |> Enum.join("\n")
+    |> Enum.map(&[&1, "\n"])
+    |> IO.chardata_to_string()
   end
 
   def format(%Counter{} = metric, time_series) do

--- a/test/exporter_test.exs
+++ b/test/exporter_test.exs
@@ -3,6 +3,37 @@ defmodule TelemetryMetricsPrometheus.Core.ExporterTest do
   alias Telemetry.Metrics
   alias TelemetryMetricsPrometheus.Core.Exporter
 
+  describe "export/2" do
+    test "non-printing characters" do
+      expected = """
+      # HELP http_request_total 
+      # TYPE http_request_total counter
+      http_request_total 1027
+      # HELP cache_key_total 
+      # TYPE cache_key_total gauge
+      cache_key_total 3
+      """
+
+      metrics = [
+        Metrics.counter("http.request.total"),
+        Metrics.last_value("cache.key.total")
+      ]
+
+      time_series = %{
+        [:http, :request, :total] => [
+          {{[:http, :request, :total], %{}}, 1027}
+        ],
+        [:cache, :key, :total] => [
+          {{[:cache, :key, :total], %{}}, 3}
+        ]
+      }
+
+      result = Exporter.export(time_series, metrics)
+
+      assert result == expected
+    end
+  end
+
   describe "format/2" do
     test "counter with tags" do
       expected = """


### PR DESCRIPTION
Hello. Thank you for this reporter.

I've tried it with telegraf prometheus input and it failed because their parser is too sensitive and requires line feed in the last line. Prometheus documentation also requires it.

> The last line must end with a line feed character

https://prometheus.io/docs/instrumenting/exposition_formats/#text-format-details

So I've decided that it should be considered as a bug and have fixed it.