### PR TITLE
Fix duplicated TYPE tag on distribution metric

### DIFF
--- a/test/exporter_test.exs
+++ b/test/exporter_test.exs
@@ -181,46 +181,6 @@ defmodule TelemetryMetricsPrometheus.Core.ExporterTest do
       http_request_duration_seconds_bucket{method="GET",le="1"} 133988
       http_request_duration_seconds_bucket{method="GET",le="+Inf"} 144320
       http_request_duration_seconds_sum{method="GET"} 53423
-      http_request_duration_seconds_count{method="GET"} 144320\
-      """
-
-      metric =
-        Metrics.distribution("http.request.duration.seconds",
-          buckets: [0.05, 0.1, 0.2, 0.5, 1],
-          tags: ["method"],
-          description: "A histogram of the request duration.",
-          unit: {:native, :second}
-        )
-
-      buckets = [
-        {"0.05", 24054},
-        {"0.1", 33444},
-        {"0.2", 100_392},
-        {"0.5", 129_389},
-        {"1", 133_988},
-        {"+Inf", 144_320}
-      ]
-
-      result =
-        Exporter.format(
-          metric,
-          [{{metric.name, %{"method" => "GET"}}, {buckets, 144_320, 53423}}]
-        )
-
-      assert result == expected
-    end
-
-    test "multiple distribution with tags" do
-      expected = """
-      # HELP http_request_duration_seconds A histogram of the request duration.
-      # TYPE http_request_duration_seconds histogram
-      http_request_duration_seconds_bucket{method="GET",le="0.05"} 24054
-      http_request_duration_seconds_bucket{method="GET",le="0.1"} 33444
-      http_request_duration_seconds_bucket{method="GET",le="0.2"} 100392
-      http_request_duration_seconds_bucket{method="GET",le="0.5"} 129389
-      http_request_duration_seconds_bucket{method="GET",le="1"} 133988
-      http_request_duration_seconds_bucket{method="GET",le="+Inf"} 144320
-      http_request_duration_seconds_sum{method="GET"} 53423
       http_request_duration_seconds_count{method="GET"} 144320
       http_request_duration_seconds_bucket{method="POST",le="0.05"} 24054
       http_request_duration_seconds_bucket{method="POST",le="0.1"} 33444


### PR DESCRIPTION
## Motivation

Prometheus is raising the following for our exported metrics using `telemetry_metrics_prometheus`:

```
second TYPE line for metric name "authentication_duration_seconds_bucket"
```

That is happening because the TYPE for distribution metrics are appearing multiple times, one for each tag group.

```
# HELP authentication_duration_seconds 
# TYPE authentication_duration_seconds histogram
authentication_duration_seconds_bucket{result="error",le="0.01"} 165
authentication_duration_seconds_bucket{result="error",le="0.025"} 165
authentication_duration_seconds_bucket{result="error",le="0.05"} 165
authentication_duration_seconds_bucket{result="error",le="0.1"} 165
authentication_duration_seconds_bucket{result="error",le="0.2"} 165
authentication_duration_seconds_bucket{result="error",le="0.5"} 165
authentication_duration_seconds_bucket{result="error",le="1"} 165
authentication_duration_seconds_bucket{result="error",le="2"} 165
authentication_duration_seconds_bucket{result="error",le="+Inf"} 165
authentication_duration_seconds_sum{result="error"} 0.05191320699999999
authentication_duration_seconds_count{result="error"} 165
# HELP authentication_duration_seconds 
# TYPE authentication_duration_seconds histogram
authentication_duration_seconds_bucket{result="ok",le="0.01"} 1208
authentication_duration_seconds_bucket{result="ok",le="0.025"} 1211
authentication_duration_seconds_bucket{result="ok",le="0.05"} 1213
authentication_duration_seconds_bucket{result="ok",le="0.1"} 1215
authentication_duration_seconds_bucket{result="ok",le="0.2"} 1215
authentication_duration_seconds_bucket{result="ok",le="0.5"} 1215
authentication_duration_seconds_bucket{result="ok",le="1"} 1215
authentication_duration_seconds_bucket{result="ok",le="2"} 1215
authentication_duration_seconds_bucket{result="ok",le="+Inf"} 1215
authentication_duration_seconds_sum{result="ok"} 0.6920538409999999
authentication_duration_seconds_count{result="ok"} 1215
```

## Proposed solution

Change the exporter to put the `TYPE` only one time per distribution metric.