### PR TITLE
Escape special characters

### DIFF
--- a/lib/core/exporter.ex
+++ b/lib/core/exporter.ex
@@ -29,7 +29,7 @@ defmodule TelemetryMetricsPrometheus.Core.Exporter do
 
   def format(%Distribution{} = metric, time_series) do
     name = format_name(metric.name)
-    help = "# HELP #{name} #{metric.description}"
+    help = "# HELP #{name} #{escape_help(metric.description)}"
     type = "# TYPE #{name} histogram"
 
     distributions =
@@ -68,7 +68,7 @@ defmodule TelemetryMetricsPrometheus.Core.Exporter do
 
   defp format_standard({metric, time_series}, type) do
     name = format_name(metric.name)
-    help = "# HELP #{name} #{metric.description}"
+    help = "# HELP #{name} #{escape_help(metric.description)}"
     type = "# TYPE #{name} #{type}"
 
     samples =
@@ -87,7 +87,7 @@ defmodule TelemetryMetricsPrometheus.Core.Exporter do
 
   defp format_labels(labels) do
     labels
-    |> Enum.map(fn {k, v} -> ~s(#{k}="#{v}") end)
+    |> Enum.map(fn {k, v} -> ~s/#{k}="#{escape(v)}"/ end)
     |> Enum.sort()
     |> Enum.join(",")
   end
@@ -96,5 +96,20 @@ defmodule TelemetryMetricsPrometheus.Core.Exporter do
     name
     |> Enum.join("_")
     |> String.replace(~r/[^a-zA-Z_][^a-zA-Z0-9_]*/, "")
+  end
+
+  defp escape(value) do
+    value
+    |> to_string()
+    |> String.replace(~S("), ~S(\"))
+    |> String.replace(~S(\\), ~S(\\\\))
+    |> String.replace(~S(\n), ~S(\\n))
+  end
+
+  defp escape_help(value) do
+    value
+    |> to_string()
+    |> String.replace(~S(\\), ~S(\\\\))
+    |> String.replace(~S(\n), ~S(\\n))
   end
 end


### PR DESCRIPTION
## Motivation

The exporter is creating invalid metrics when a ecto query is used as a tag value.

For example, the following line is invalid:
```
db_query_seconds_bucket{query="SELECT a0."id" FROM "users" AS a0 LIMIT $1",result="ok",source="users",le="0.01"} 1
```

Promlint shows the following error:

```
error while linting: text format parsing error in line 118: unexpected end of label value "SELECT a0."
```

## Proposed solution

Escape all tag values putting a `\` before any double quotes.
Based on the implementation of other client libraries, escape `\\`, `\n` and `"`.

References: 
- https://github.com/prometheus/client_ruby/blob/master/lib/prometheus/client/formats/text.rb#L84
- https://github.com/prometheus/client_python/blob/3ab0374d1548769748932b9316d86b088dc7712e/prometheus_client/parser.py#L31
- https://github.com/deadtrickster/prometheus.erl/blob/master/src/formats/prometheus_text_format.erl#L156
- https://github.com/deadtrickster/prometheus.erl/blob/master/src/formats/prometheus_text_format.erl#L43
