### PR TITLE
Log and skip bad events vs raising

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -113,3 +113,7 @@ exceeding the limit of the last bucket - `+Inf`.*
 It is recommended, but not required, to abide by Prometheus' best practices regarding labels -
 [Label Best Practices](https://prometheus.io/docs/practices/naming/#labels)
 
+### Missing or Invalid Measurements and Tags
+
+If a measurement value is missing or non-numeric, the error is logged at the `debug` level
+and the event is not recorded. Events with missing tags are also logged and skipped.

--- a/lib/core.ex
+++ b/lib/core.ex
@@ -100,6 +100,11 @@ defmodule TelemetryMetricsPrometheus.Core do
   It is recommended, but not required, to abide by Prometheus' best practices regarding labels -
   [Label Best Practices](https://prometheus.io/docs/practices/naming/#labels)
 
+  ### Missing or Invalid Measurements and Tags
+
+  If a measurement value is missing or non-numeric, the error is logged at the `debug` level
+  and the event is not recorded. Events with missing tags are also logged and skipped.
+
   """
 
   alias Telemetry.Metrics

--- a/lib/core/event_handler.ex
+++ b/lib/core/event_handler.ex
@@ -31,9 +31,9 @@ defmodule TelemetryMetricsPrometheus.Core.EventHandler do
   @spec get_measurement(:telemetry.event_measurements(), atom()) ::
           {:ok, number()} | measurement_not_found_error() | measurement_parse_error()
   def get_measurement(measurements, measurement) when is_atom(measurement) do
-    case Map.fetch(measurements, measurement) do
-      :error -> {:measurement_not_found, measurement}
-      {:ok, value} -> parse_measurement(value)
+    case Map.get(measurements, measurement) do
+      nil -> {:measurement_not_found, measurement}
+      value -> parse_measurement(value)
     end
   end
 
@@ -46,23 +46,24 @@ defmodule TelemetryMetricsPrometheus.Core.EventHandler do
 
   @spec handle_event_error(event_error(), event_config) :: no_return()
   def handle_event_error({:measurement_not_found, measurement}, config) do
-    raise ArgumentError,
-          "Measurement not found, expected: #{measurement}. Detaching handler. metric_name:=#{
-            inspect(config.name)
-          }"
+    Logger.debug(
+      "Measurement not found, expected: #{measurement}. metric_name:=#{inspect(config.name)}"
+    )
   end
 
   def handle_event_error({:measurement_parse_error, term}, config) do
-    raise ArgumentError,
-          "Expected measurement to be a number, got: #{inspect(term)}. Detaching handler. metric_name:=#{
-            inspect(config.name)
-          }"
+    Logger.debug(
+      "Expected measurement to be a number, got: #{inspect(term)}. metric_name:=#{
+        inspect(config.name)
+      }"
+    )
   end
 
   def handle_event_error({:tags_missing, tags}, config) do
-    raise ArgumentError,
-          "Tags missing from tag_values. Detaching handler. metric_name:=#{inspect(config.name)} tags:=#{
-            inspect(Enum.join(tags))
-          }"
+    Logger.debug(
+      "Tags missing from tag_values. metric_name:=#{inspect(config.name)} tags:=#{
+        inspect(Enum.join(tags))
+      }"
+    )
   end
 end

--- a/lib/core/event_handler.ex
+++ b/lib/core/event_handler.ex
@@ -37,7 +37,10 @@ defmodule TelemetryMetricsPrometheus.Core.EventHandler do
     end
   end
 
-  def get_measurement(measurements, measurement), do: {:ok, measurement.(measurements)}
+  def get_measurement(measurements, measurement_fun) do
+    measurement_fun.(measurements)
+    |> parse_measurement()
+  end
 
   # Not sure if we should be handling this. Should reporters be responsible for bad actors?
   @spec parse_measurement(term) :: {:ok, number()} | no_return()

--- a/test/metrics_test.exs
+++ b/test/metrics_test.exs
@@ -287,7 +287,7 @@ defmodule TelemetryMetricsPrometheus.Core.MetricsTest do
            measurement: :measure
          ), LastValue, tid},
         {Metrics.sum("test.event.measure",
-           measurement: :measure
+           measurement: fn _ -> "this isn't a number..." end
          ), Sum, tid},
         {Metrics.distribution("test.event.measure",
            buckets: [1, 2, 3],

--- a/test/metrics_test.exs
+++ b/test/metrics_test.exs
@@ -281,7 +281,7 @@ defmodule TelemetryMetricsPrometheus.Core.MetricsTest do
       end)
     end
 
-    test "detaches handler for non-numeric measurement", %{tid: tid, dist_tid: dist_tid} do
+    test "logs an error for non-numeric measurement", %{tid: tid, dist_tid: dist_tid} do
       [
         {Metrics.last_value("test.event.measure",
            measurement: :measure
@@ -309,7 +309,7 @@ defmodule TelemetryMetricsPrometheus.Core.MetricsTest do
       end)
     end
 
-    test "detaches handler for missing tags", %{tid: tid, dist_tid: dist_tid} do
+    test "logs an error for missing tags", %{tid: tid, dist_tid: dist_tid} do
       [
         {Metrics.counter("test.event.measure",
            measurement: :measure,


### PR DESCRIPTION
Bad events currently raise an error, forcing a detach the handler. According to the Reporter spec, these events should simply be skipped.