### PR TITLE
Filter and drop aggregates with bad tag values

### DIFF
--- a/test/exporter_test.exs
+++ b/test/exporter_test.exs
@@ -82,7 +82,8 @@ defmodule TelemetryMetricsPrometheus.Core.ExporterTest do
 
     test "counter escape tags and help" do
       expected =
-        ~S(# HELP db_query_total The total number of DB queries. \\\\ \\n) <> "\n" <>
+        ~S(# HELP db_query_total The total number of DB queries. \\\\ \\n) <>
+          "\n" <>
           "# TYPE db_query_total counter\n" <>
           ~S(db_query_total{query="SELECT a0.\"id\" FROM \"users\" AS a0 WHERE LIMIT $1"} 1027) <>
           "\n" <>


### PR DESCRIPTION
If a value is recorded for a tag that isn't readily formattable during export such as #18 then the entire export will fail. Rather than validating values as they arrive, it's less taxing to perform this validation during export and dropping the aggregation if the value isn't printable.

This type of situation is very difficult to debug since you must manually walk the aggregation table to find the offender. This should enable users to fix these problems more quickly while continuing to allow metrics to be reported.

Resolves #18 