### PR TITLE
Remove unit validations

### DIFF
--- a/lib/core.ex
+++ b/lib/core.ex
@@ -117,7 +117,6 @@ defmodule TelemetryMetricsPrometheus.Core do
   @type prometheus_option ::
           {:metrics, metrics()}
           | {:name, atom()}
-          | {:validations, Registry.validation_opts() | false}
 
   @type prometheus_options :: [prometheus_option()]
 
@@ -156,9 +155,6 @@ defmodule TelemetryMetricsPrometheus.Core do
 
   Available options:
   * `:name` - name of the reporter instance. Defaults to `:prometheus_metrics`
-  * `:validations` - Keyword options list to control validations. All validations can be disabled by setting `validations: false`.
-  * `:consistent_units` - logs a warning when mixed time units are found in your definitions. Defaults to `true`
-  * `:require_seconds` - logs a warning if units other than seconds are found in your definitions. Defaults to `true`
   * `:metrics` - a list of metrics to track.
   """
   @spec start_link(prometheus_options()) :: GenServer.on_start()
@@ -185,32 +181,13 @@ defmodule TelemetryMetricsPrometheus.Core do
 
   @spec ensure_options(prometheus_options()) :: prometheus_options()
   defp ensure_options(options) do
-    validation_opts = ensure_validation_options(Keyword.get(options, :validations, []))
-
     Keyword.merge(default_options(), options)
-    |> Keyword.put(:validations, validation_opts)
   end
 
   @spec default_options() :: prometheus_options()
   defp default_options() do
     [
-      name: :prometheus_metrics,
-      validations: default_validation_options()
+      name: :prometheus_metrics
     ]
   end
-
-  @spec ensure_validation_options(bool() | Registry.validation_opts()) ::
-          Registry.validation_opts()
-  defp ensure_validation_options(false), do: default_validation_options(false)
-
-  defp ensure_validation_options(opts) do
-    Keyword.merge(default_validation_options(), opts)
-  end
-
-  @spec default_validation_options(bool()) :: Registry.validation_opts()
-  defp default_validation_options(on \\ true),
-    do: [
-      consistent_units: on,
-      require_seconds: on
-    ]
 end

--- a/test/core_test.exs
+++ b/test/core_test.exs
@@ -14,7 +14,6 @@ defmodule CoreTest do
                {Core.Registry, :start_link,
                 [
                   [
-                    validations: [consistent_units: true, require_seconds: true],
                     name: :prometheus_metrics,
                     metrics: []
                   ]
@@ -38,8 +37,7 @@ defmodule CoreTest do
     ]
 
     opts = [
-      name: :test_reporter,
-      validations: [require_seconds: false]
+      name: :test_reporter
     ]
 
     :ok = init_and_wait(metrics, opts)

--- a/test/registry_test.exs
+++ b/test/registry_test.exs
@@ -4,8 +4,6 @@ defmodule TelemetryMetricsPrometheus.Core.RegistryTest do
   alias Telemetry.Metrics
   alias TelemetryMetricsPrometheus.Core.Registry
 
-  import ExUnit.CaptureLog
-
   setup do
     definitions = [
       Metrics.counter("http.request.count"),
@@ -100,42 +98,6 @@ defmodule TelemetryMetricsPrometheus.Core.RegistryTest do
       )
       |> Registry.validate_distribution_buckets!()
     end
-  end
-
-  test "validates for units" do
-    metrics = [
-      Metrics.distribution("some.plug.call.duration",
-        reporter_options: [
-          buckets: [0, 1, 2]
-        ],
-        unit: {:native, :millisecond}
-      ),
-      Metrics.distribution("some_other.plug.call.duration",
-        reporter_options: [
-          buckets: [0, 1, 2]
-        ],
-        unit: {:microsecond, :second}
-      ),
-      Metrics.distribution("some_third.plug.call.duration",
-        reporter_options: [buckets: [0, 1, 2]],
-        unit: :millisecond
-      ),
-      Metrics.counter("http.request.count", unit: :byte)
-    ]
-
-    assert capture_log(fn ->
-             Registry.validate_units(metrics,
-               consistent_units: true,
-               require_seconds: false
-             )
-           end) =~ "Multiple time units found"
-
-    assert capture_log(fn ->
-             Registry.validate_units(metrics,
-               consistent_units: false,
-               require_seconds: true
-             )
-           end) =~ "Prometheus requires that time units MUST only be offered in seconds"
   end
 
   test "retrieves the config", %{opts: opts} do


### PR DESCRIPTION
The value of unit validations are proving to not be worth the hassle to users. Highlighting the guidelines in the Prometheus documentation should be sufficient.

Resolves #21 