### PR TITLE
Switched to handle_continue and added flag to start synchronously

### DIFF
--- a/lib/core.ex
+++ b/lib/core.ex
@@ -131,7 +131,7 @@ defmodule TelemetryMetricsPrometheus.Core do
     {TelemetryMetricsPrometheus.Core, options}
   ]
 
-  See `start_child/1` for options.
+  See `start_link/1` for options.
   """
   @spec child_spec(prometheus_options()) :: Supervisor.child_spec()
   def child_spec(options) do
@@ -158,6 +158,12 @@ defmodule TelemetryMetricsPrometheus.Core do
   Available options:
   * `:name` - name of the reporter instance. Defaults to `:prometheus_metrics`
   * `:metrics` - a list of metrics to track.
+  * `:start_async - used to configure how the `TelemetryMetricsPrometheus.Core.Supervisor`
+    GenServer starts. When set to false, all of the metrics defined in `:metrics` are
+    initialized in the GenServer's `init/1` callback effectively blocking the supervision
+    tree from proceeding until all Telemetry event handlers are initialized. This is
+    useful if subsequent supervision tree children emit events on start up and you don't
+    want to miss those events due to an async start. Defaults to `true`.
   """
   @spec start_link(prometheus_options()) :: GenServer.on_start()
   def start_link(options) do

--- a/lib/core/counter.ex
+++ b/lib/core/counter.ex
@@ -25,7 +25,7 @@ defmodule TelemetryMetricsPrometheus.Core.Counter do
            :telemetry.attach(
              handler_id,
              metric.event_name,
-             &handle_event/4,
+             &__MODULE__.handle_event/4,
              %{
                keep: metric.keep,
                metric_name: "",

--- a/lib/core/distribution.ex
+++ b/lib/core/distribution.ex
@@ -39,7 +39,7 @@ defmodule TelemetryMetricsPrometheus.Core.Distribution do
            :telemetry.attach(
              handler_id,
              metric.event_name,
-             &handle_event/4,
+             &__MODULE__.handle_event/4,
              %{
                keep: metric.keep,
                measurement: metric.measurement,

--- a/lib/core/last_value.ex
+++ b/lib/core/last_value.ex
@@ -25,7 +25,7 @@ defmodule TelemetryMetricsPrometheus.Core.LastValue do
            :telemetry.attach(
              handler_id,
              metric.event_name,
-             &handle_event/4,
+             &__MODULE__.handle_event/4,
              %{
                keep: metric.keep,
                measurement: metric.measurement,

--- a/lib/core/registry.ex
+++ b/lib/core/registry.ex
@@ -159,10 +159,7 @@ defmodule TelemetryMetricsPrometheus.Core.Registry do
     :ets.new(name, [:named_table, :public, type, {:write_concurrency, true}])
   end
 
-  @spec register_metrics(
-          [Metrics.t()],
-          %{}
-        ) :: [Metrics.t()]
+  @spec register_metrics([Metrics.t()], map()) :: [Metrics.t()]
   defp register_metrics(metrics, config) do
     metrics
     |> Enum.reduce([], fn metric, acc ->

--- a/lib/core/registry.ex
+++ b/lib/core/registry.ex
@@ -38,7 +38,9 @@ defmodule TelemetryMetricsPrometheus.Core.Registry do
     }
 
     if start_async do
-      {:ok, state, {:continue, {:setup, opts}}}
+      send(self(), {:setup, opts})
+
+      {:ok, state}
     else
       registered = setup_registry(opts, state.config)
 
@@ -114,7 +116,7 @@ defmodule TelemetryMetricsPrometheus.Core.Registry do
   end
 
   @impl true
-  def handle_continue({:setup, opts}, state) do
+  def handle_info({:setup, opts}, state) do
     registered = setup_registry(opts, state.config)
 
     {:noreply, %{state | metrics: registered}}

--- a/lib/core/sum.ex
+++ b/lib/core/sum.ex
@@ -25,7 +25,7 @@ defmodule TelemetryMetricsPrometheus.Core.Sum do
            :telemetry.attach(
              handler_id,
              metric.event_name,
-             &handle_event/4,
+             &__MODULE__.handle_event/4,
              %{
                keep: metric.keep,
                measurement: metric.measurement,

--- a/test/core_test.exs
+++ b/test/core_test.exs
@@ -55,6 +55,80 @@ defmodule CoreTest do
     assert metrics_scrape =~ "http_request_total"
   end
 
+  test "initializes properly when configured via start_async" do
+    metrics = [
+      Metrics.counter("http.request.total",
+        event_name: [:http, :request, :stop],
+        tags: [:method, :code],
+        description: "The total number of HTTP requests."
+      )
+    ]
+
+    async_opts = [
+      name: :test_reporter_async,
+      validations: [require_seconds: false],
+      start_async: true,
+      metrics: metrics
+    ]
+
+    sync_opts = [
+      name: :test_reporter_sync,
+      validations: [require_seconds: false],
+      start_async: false,
+      metrics: metrics
+    ]
+
+    async_pid =
+      start_supervised!(%{
+        id: Keyword.get(async_opts, :name),
+        start:
+          {GenServer, :start_link,
+           [
+             Core.Registry,
+             async_opts,
+             [name: Keyword.get(async_opts, :name), debug: [:statistics]]
+           ]}
+      })
+
+    sync_pid =
+      start_supervised!(%{
+        id: Keyword.get(sync_opts, :name),
+        start:
+          {GenServer, :start_link,
+           [
+             Core.Registry,
+             sync_opts,
+             [name: Keyword.get(sync_opts, :name), debug: [:statistics]]
+           ]}
+      })
+
+    Process.sleep(100)
+
+    assert :ets.info(:test_reporter_async) != :undefined
+    assert :ets.info(:test_reporter_async_dist) != :undefined
+
+    assert :ets.info(:test_reporter_sync) != :undefined
+    assert :ets.info(:test_reporter_sync_dist) != :undefined
+
+    :telemetry.execute([:http, :request, :stop], %{duration: 300_000_000}, %{
+      method: "get",
+      code: 200
+    })
+
+    async_metrics_scrape = Core.scrape(Keyword.get(async_opts, :name))
+    sync_metrics_scrape = Core.scrape(Keyword.get(sync_opts, :name))
+
+    {:ok, async_stats} = :sys.statistics(async_pid, :get)
+    {:ok, sync_stats} = :sys.statistics(sync_pid, :get)
+
+    # The async Registry should have 1 more message processed from the inbox
+    # due to the handle_info setup call triggered in init
+    assert Keyword.get(async_stats, :messages_in) > Keyword.get(sync_stats, :messages_in)
+
+    assert async_metrics_scrape =~ "http_request_total"
+    assert sync_metrics_scrape =~ "http_request_total"
+  end
+
   test "initializes properly via start_link" do
     metrics = [
       Metrics.counter("http.request.total",


### PR DESCRIPTION
The purpose of this PR is two fold. 

One is to leverage the GenServer `handle_continue` callback as to guarantee that the initialization steps for the GenServer are the first things that take place upon spawning the process. I ran into some issues where `telemetry_metrics_prometheus_core` was being started as part of a supervision tree and I was getting inconsistent results on app start. 

The second change is to add a flag to either init the process in the init function (in turn blocking the rest of the supervision tree from starting) or leveraging the `handle_continue` callback. The reason for this change is that if the supervision tree is allowed to continue without metrics being in place, you have a short window of time where you can miss telemetry events being emitted. The change currently has the default of using the `handle_continue` callback so the process behaviour is in line with what is in master today.

Thanks in advance for the review :)