### PR TITLE
Add reporter option to allow gauges for summed metrics

### DIFF
--- a/lib/core.ex
+++ b/lib/core.ex
@@ -12,6 +12,7 @@ defmodule TelemetryMetricsPrometheus.Core do
             metrics: [
               counter("http.request.count"),
               sum("http.request.payload_size", unit: :byte),
+              sum("websocket.connection.count", reporter_options: [prometheus_type: :gauge]),
               last_value("vm.memory.total", unit: :byte)
             ]
           ]}
@@ -101,6 +102,38 @@ defmodule TelemetryMetricsPrometheus.Core do
 
   It is recommended, but not required, to abide by Prometheus' best practices regarding labels -
   [Label Best Practices](https://prometheus.io/docs/practices/naming/#labels)
+
+  ### Reporter Options
+
+  In some cases you may want to configure the aspects of a metric definition's
+  underlying Prometheus metric, such as the bucket boundaries for a
+  distribution. This can be achieved by passing `:reporter_options` to the
+  metric definition.
+
+  The supported `:reporter_options` are:
+
+  - `:buckets` - a list of bucket boundaries for distributions. This reporter
+  option is mandatory for `distributions`. Example:
+
+  Example:
+
+      Metrics.distribution(
+        "http.request.duration.seconds",
+        event_name: [:http, :request, :complete],
+        measurement: :duration,
+        unit: {:native, :second},
+        reporter_options: [
+          buckets: [0.01, 0.025, 0.05, 0.1, 0.2, 0.5, 1]
+        ]
+      )
+
+  - `:prometheus_type` - the Prometheus type that should be used for a sum,
+  either `:counter` or `:gauge`.  Prometheus counters are monotonic, so a gauge
+  should be used when a sum can increase and decrease. Defaults to `:counter`.
+
+  Example:
+
+      Metrics.sum("websocket.connection.count", reporter_options: [prometheus_type: :gauge])
 
   ### Missing or Invalid Measurements and Tags
 

--- a/lib/core.ex
+++ b/lib/core.ex
@@ -32,7 +32,7 @@ defmodule TelemetryMetricsPrometheus.Core do
     * Counter - Counter
     * Distribution - Histogram
     * LastValue - Gauge
-    * Sum - Counter
+    * Sum - Counter/Gauge
     * Summary - Summary (Not supported)
 
   ### Units

--- a/lib/core/exporter.ex
+++ b/lib/core/exporter.ex
@@ -24,7 +24,15 @@ defmodule TelemetryMetricsPrometheus.Core.Exporter do
   end
 
   def format(%Sum{} = metric, time_series) do
-    format_standard({metric, time_series}, "counter")
+    type =
+      metric.reporter_options
+      |> Keyword.get(
+        :preometheus_type,
+        TelemetryMetricsPrometheus.Core.Sum.default_prometheus_type()
+      )
+      |> Atom.to_string()
+
+    format_standard({metric, time_series}, type)
   end
 
   def format(%Distribution{} = metric, time_series) do

--- a/lib/core/exporter.ex
+++ b/lib/core/exporter.ex
@@ -27,7 +27,7 @@ defmodule TelemetryMetricsPrometheus.Core.Exporter do
     type =
       metric.reporter_options
       |> Keyword.get(
-        :preometheus_type,
+        :prometheus_type,
         TelemetryMetricsPrometheus.Core.Sum.default_prometheus_type()
       )
       |> Atom.to_string()

--- a/lib/core/registry.ex
+++ b/lib/core/registry.ex
@@ -220,6 +220,8 @@ defmodule TelemetryMetricsPrometheus.Core.Registry do
   end
 
   defp register_metric(%Metrics.Sum{} = metric, config) do
+    validate_prometheus_type!(metric)
+
     case Sum.register(metric, config.aggregates_table_id, self()) do
       {:ok, handler_id} -> {:ok, {metric, handler_id}}
       {:error, :already_exists} -> {:error, :already_exists, metric.name}
@@ -228,7 +230,6 @@ defmodule TelemetryMetricsPrometheus.Core.Registry do
 
   defp register_metric(%Metrics.Distribution{} = metric, config) do
     validate_distribution_buckets!(metric)
-    validate_prometheus_type!(metric)
 
     case Distribution.register(metric, config.dist_table_id, self()) do
       {:ok, handler_id} ->

--- a/lib/core/sum.ex
+++ b/lib/core/sum.ex
@@ -20,6 +20,7 @@ defmodule TelemetryMetricsPrometheus.Core.Sum do
 
   def register(metric, table_id, owner) do
     handler_id = EventHandler.handler_id(metric.name, owner)
+    type = Keyword.get(metric.reporter_options, :prometheus_type, default_prometheus_type())
 
     with :ok <-
            :telemetry.attach(
@@ -34,7 +35,7 @@ defmodule TelemetryMetricsPrometheus.Core.Sum do
                table: table_id,
                tags: metric.tags,
                tag_values_fun: metric.tag_values,
-               type: :sum
+               type: type
              }
            ) do
       {:ok, handler_id}
@@ -65,4 +66,7 @@ defmodule TelemetryMetricsPrometheus.Core.Sum do
       error -> EventHandler.handle_event_error(error, config)
     end
   end
+
+  @spec default_prometheus_type() :: :counter
+  def default_prometheus_type(), do: :counter
 end

--- a/test/exporter_test.exs
+++ b/test/exporter_test.exs
@@ -163,7 +163,7 @@ defmodule TelemetryMetricsPrometheus.Core.ExporterTest do
         Metrics.sum("cache.key.invalidations.total",
           tags: ["name"],
           description: "The total number of cache key invalidations.",
-          reporter_options: [preometheus_type: :gauge]
+          reporter_options: [prometheus_type: :gauge]
         )
 
       time_series = [

--- a/test/exporter_test.exs
+++ b/test/exporter_test.exs
@@ -151,6 +151,31 @@ defmodule TelemetryMetricsPrometheus.Core.ExporterTest do
       assert result == expected
     end
 
+    test "sum with specified type" do
+      expected = """
+      # HELP cache_key_invalidations_total The total number of cache key invalidations.
+      # TYPE cache_key_invalidations_total gauge
+      cache_key_invalidations_total{name="users"} 1027
+      cache_key_invalidations_total{name="short_urls"} 3\
+      """
+
+      metric =
+        Metrics.sum("cache.key.invalidations.total",
+          tags: ["name"],
+          description: "The total number of cache key invalidations.",
+          reporter_options: [preometheus_type: :gauge]
+        )
+
+      time_series = [
+        {{[:cache, :key, :invalidations, :total], %{"name" => "users"}}, 1027},
+        {{[:cache, :key, :invalidations, :total], %{"name" => "short_urls"}}, 3}
+      ]
+
+      result = Exporter.format(metric, time_series)
+
+      assert result == expected
+    end
+
     test "sum with tags" do
       expected = """
       # HELP cache_key_invalidations_total The total number of cache key invalidations.

--- a/test/registry_test.exs
+++ b/test/registry_test.exs
@@ -109,7 +109,7 @@ defmodule TelemetryMetricsPrometheus.Core.RegistryTest do
     assert Metrics.sum("som.plug.call.total", reporter_options: [preometheus_type: :counter])
            |> Registry.validate_prometheus_type!() == :ok
 
-    assert Metrics.sum("som.plug.call.total", reporter_options: [preometheus_type: :gauge])
+    assert Metrics.sum("some.plug.call.total", reporter_options: [prometheus_type: :gauge])
            |> Registry.validate_prometheus_type!() == :ok
 
     assert Metrics.sum("som.plug.call.total", reporter_options: [])

--- a/test/registry_test.exs
+++ b/test/registry_test.exs
@@ -112,7 +112,7 @@ defmodule TelemetryMetricsPrometheus.Core.RegistryTest do
     assert Metrics.sum("some.plug.call.total", reporter_options: [prometheus_type: :gauge])
            |> Registry.validate_prometheus_type!() == :ok
 
-    assert Metrics.sum("som.plug.call.total", reporter_options: [])
+    assert Metrics.sum("some.plug.call.total", reporter_options: [])
            |> Registry.validate_prometheus_type!() == :ok
 
     assert Metrics.sum("som.plug.call.total")

--- a/test/registry_test.exs
+++ b/test/registry_test.exs
@@ -115,7 +115,7 @@ defmodule TelemetryMetricsPrometheus.Core.RegistryTest do
     assert Metrics.sum("some.plug.call.total", reporter_options: [])
            |> Registry.validate_prometheus_type!() == :ok
 
-    assert Metrics.sum("som.plug.call.total")
+    assert Metrics.sum("some.plug.call.total")
            |> Registry.validate_prometheus_type!() == :ok
   end
 

--- a/test/registry_test.exs
+++ b/test/registry_test.exs
@@ -100,7 +100,7 @@ defmodule TelemetryMetricsPrometheus.Core.RegistryTest do
     end
   end
 
-  test "validates for preometheus_type" do
+  test "validates for prometheus_type" do
     assert_raise ArgumentError, fn ->
       Metrics.sum("some.plug.call.total", reporter_options: [prometheus_type: :invalid])
       |> Registry.validate_prometheus_type!()

--- a/test/registry_test.exs
+++ b/test/registry_test.exs
@@ -106,7 +106,7 @@ defmodule TelemetryMetricsPrometheus.Core.RegistryTest do
       |> Registry.validate_prometheus_type!()
     end
 
-    assert Metrics.sum("som.plug.call.total", reporter_options: [preometheus_type: :counter])
+    assert Metrics.sum("some.plug.call.total", reporter_options: [prometheus_type: :counter])
            |> Registry.validate_prometheus_type!() == :ok
 
     assert Metrics.sum("some.plug.call.total", reporter_options: [prometheus_type: :gauge])

--- a/test/registry_test.exs
+++ b/test/registry_test.exs
@@ -100,6 +100,25 @@ defmodule TelemetryMetricsPrometheus.Core.RegistryTest do
     end
   end
 
+  test "validates for preometheus_type" do
+    assert_raise ArgumentError, fn ->
+      Metrics.sum("some.plug.call.total", reporter_options: [prometheus_type: :invalid])
+      |> Registry.validate_prometheus_type!()
+    end
+
+    assert Metrics.sum("som.plug.call.total", reporter_options: [preometheus_type: :counter])
+           |> Registry.validate_prometheus_type!() == :ok
+
+    assert Metrics.sum("som.plug.call.total", reporter_options: [preometheus_type: :gauge])
+           |> Registry.validate_prometheus_type!() == :ok
+
+    assert Metrics.sum("som.plug.call.total", reporter_options: [])
+           |> Registry.validate_prometheus_type!() == :ok
+
+    assert Metrics.sum("som.plug.call.total")
+           |> Registry.validate_prometheus_type!() == :ok
+  end
+
   test "retrieves the config", %{opts: opts} do
     {:ok, _pid} = start_supervised({Registry, opts})
     config = Registry.config(:test)


### PR DESCRIPTION
👋 Hopefully the commit message below gives a decent explanation behind the motivations for making a change like this.

I've opened this PR to get your feedback and see if it's something that might be considered - feel free to close this out if not  😄 
Likewise if there's an alternative idea as to how to implement this I'd be more than happy to rework this PR.

Thanks for your work on this package, using it has been a breeze!

## Commit Message

Some summed metrics can decrease as well as increase, in which case a
Prometheus counter isn't suitable as they are monotonic. A Prometheus
gauge fits nicely as it allows for arbitrary increases and decreases
value.

At the moment, it's only possible to get a gauge from `last_value`,
meaning if you want to report a sum goes up and down, you currently need
to sum the value yourself and make it available to `last_value` via
something like `telemetry_metrics_poller`.

This commit allows users to pass the `:prometheus_type` reporter option
when declaring a `sum`, which determines whether the metric exported to
prometheus is a counter or a gauge.