### PR TITLE
Allow names with digits, strip leading digits

### DIFF
--- a/lib/core/exporter.ex
+++ b/lib/core/exporter.ex
@@ -95,7 +95,8 @@ defmodule TelemetryMetricsPrometheus.Core.Exporter do
   defp format_name(name) do
     name
     |> Enum.join("_")
-    |> String.replace(~r/[^a-zA-Z_][^a-zA-Z0-9_]*/, "")
+    |> String.replace(~r/[^a-zA-Z0-9_]/, "")
+    |> String.replace(~r/^[^a-zA-Z]+/, "")
   end
 
   defp escape(value) do

--- a/test/exporter_test.exs
+++ b/test/exporter_test.exs
@@ -281,5 +281,41 @@ defmodule TelemetryMetricsPrometheus.Core.ExporterTest do
 
       assert result == expected
     end
+
+    test "allow names with digits" do
+      expected = """
+      # HELP foo123_bar_total FOO123 BAR total
+      # TYPE foo123_bar_total counter
+      foo123_bar_total 1027\
+      """
+
+      metric = Metrics.counter("foo123.bar.total", description: "FOO123 BAR total")
+
+      time_series = [
+        {{[:foo123, :bar, :total], %{}}, 1027}
+      ]
+
+      result = Exporter.format(metric, time_series)
+
+      assert result == expected
+    end
+
+    test "strip leading digits from names" do
+      expected = """
+      # HELP foo_bar_total 123FOO BAR total
+      # TYPE foo_bar_total counter
+      foo_bar_total 1027\
+      """
+
+      metric = Metrics.counter("123foo.bar.total", description: "123FOO BAR total")
+
+      time_series = [
+        {{[:"123foo", :bar, :total], %{}}, 1027}
+      ]
+
+      result = Exporter.format(metric, time_series)
+
+      assert result == expected
+    end
   end
 end


### PR DESCRIPTION
Hi,

we have problems with the auto-generated metric names as we are using them for some libraries with digits in their name and the exporter strips these digits from the names.

Our example is `[:m3ua, :msg, :rx, :count]` which gets converted to `mua_msg_rx_count` instead of `m3ua_msg_rx_count`.

According to prometheus naming conventions digits are allowed but not in the leading position (`[a-zA-Z_][a-zA-Z0-9_]*` taken from  [docs](https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels)).

This PR changes the regex used by String.replace.

There are also two new test cases to verify the changes. All tests are passing.

Thanks in advance!
