### PR TITLE
Support telemetry v1.0.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule TelemetryMetricsPrometheus.Core.MixProject do
   defp deps do
     [
       {:telemetry_metrics, "~> 0.6"},
-      {:telemetry, "~> 0.4"},
+      {:telemetry, "~> 0.4 or ~> 1.0.0"},
       {:dialyxir, "~> 1.0.0", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.23", only: [:dev, :docs]},
       {:excoveralls, "~> 0.13.4", only: :test, runtime: false}


### PR DESCRIPTION
Support https://github.com/beam-telemetry/telemetry/releases/tag/v1.0.0:
`There are no changes in the 1.0.0 release - it marks the stability of the API.`