### PR TITLE
Make atoms and string keys the same in aggregator

### DIFF
--- a/lib/core/aggregator.ex
+++ b/lib/core/aggregator.ex
@@ -86,6 +86,10 @@ defmodule TelemetryMetricsPrometheus.Core.Aggregator do
   end
 
   @spec get_aggregation(key :: key(), table :: atom()) :: {} | aggregation()
+  defp get_aggregation(key, table) when is_atom(key) do
+    get_aggregation(to_string(key), table)
+  end
+  
   defp get_aggregation(key, table) do
     case :ets.lookup(table, key) do
       [] -> {}
@@ -95,6 +99,10 @@ defmodule TelemetryMetricsPrometheus.Core.Aggregator do
 
   @spec put_aggregation(aggregation :: nil | aggregation(), key :: key(), table :: atom()) :: true
   def put_aggregation(nil, _, _), do: true
+
+  def put_aggregation(aggregation, key, tid) when is_atom(key) do
+    put_aggregation(aggregation, to_string(key), tid)
+  end
 
   def put_aggregation(aggregation, key, tid) do
     :ets.insert(tid, {key, aggregation})


### PR DESCRIPTION
The reason i think this is important is because they show up the same in the exporter since atoms and string serialize the same. 
The end result is you get two metrics with the same labels in your prometheus output which causes prometheus to fail to be able to scrape the endpoint due to bad data (duplicated entries)

To resolve this I suggest this PR which makes atoms and strings fundamentally the same in the aggregator to it's internal ETS table