### PR TITLE
ft: allow specifying `last_value` metric type

### DIFF
--- a/lib/core/last_value.ex
+++ b/lib/core/last_value.ex
@@ -20,6 +20,7 @@ defmodule TelemetryMetricsPrometheus.Core.LastValue do
 
   def register(metric, table_id, owner) do
     handler_id = EventHandler.handler_id(metric.name, owner)
+    type = Keyword.get(metric.reporter_options, :prometheus_type, default_prometheus_type())
 
     with :ok <-
            :telemetry.attach(
@@ -34,7 +35,7 @@ defmodule TelemetryMetricsPrometheus.Core.LastValue do
                table: table_id,
                tags: metric.tags,
                tag_values_fun: metric.tag_values,
-               type: :gauge
+               type: type
              }
            ) do
       {:ok, handler_id}
@@ -66,4 +67,7 @@ defmodule TelemetryMetricsPrometheus.Core.LastValue do
       error -> EventHandler.handle_event_error(error, config)
     end
   end
+
+  @spec default_prometheus_type() :: :gauge
+  def default_prometheus_type(), do: :gauge
 end


### PR DESCRIPTION
This behaviour may be useful for example when you have `sum` type, but with pre summed value (for example output of `:inet.getstats/{1,2}`). This reduces need for keeping previous state to be able to compute difference just to recompute sum immediately.

Close #67 