### PR TITLE
chore: removed deprecated match of range

### DIFF
--- a/lib/core/registry.ex
+++ b/lib/core/registry.ex
@@ -84,7 +84,7 @@ defmodule TelemetryMetricsPrometheus.Core.Registry do
     buckets
   end
 
-  def validate_distribution_buckets!({first..last, step} = buckets) when is_integer(step) do
+  def validate_distribution_buckets!({first..last//_, step} = buckets) when is_integer(step) do
     if first >= last do
       raise ArgumentError, "expected buckets range to be ascending, got #{inspect(buckets)}"
     end


### PR DESCRIPTION
fixes a build warning on modern versions of elixir where matching without step is deprecated

```
warning: first..last inside match is deprecated, you must always match on the step: first..last//var or first..last//_ if you want to ignore it
```