### PR TITLE
Add UNIT to exposition

### DIFF
--- a/lib/core/exporter.ex
+++ b/lib/core/exporter.ex
@@ -39,13 +39,14 @@ defmodule TelemetryMetricsPrometheus.Core.Exporter do
     name = format_name(metric.name)
     help = "# HELP #{name} #{escape_help(metric.description)}"
     type = "# TYPE #{name} histogram"
+    unit = "# UNIT #{name} #{metric.unit}"
 
     distributions =
       Enum.map_join(time_series, "\n", fn ts ->
         format_distribution(metric, ts)
       end)
 
-    Enum.join([help, type, distributions], "\n")
+    Enum.join([help, type, unit, distributions], "\n")
   end
 
   def format_distribution(metric, {{_, labels}, {buckets, count, sum}}) do
@@ -76,6 +77,7 @@ defmodule TelemetryMetricsPrometheus.Core.Exporter do
     name = format_name(metric.name)
     help = "# HELP #{name} #{escape_help(metric.description)}"
     type = "# TYPE #{name} #{type}"
+    unit = "# UNIT #{name} #{metric.unit}"
 
     samples =
       Enum.map_join(time_series, "\n", fn {{_, labels}, val} ->
@@ -88,7 +90,7 @@ defmodule TelemetryMetricsPrometheus.Core.Exporter do
         end
       end)
 
-    Enum.join([help, type, samples], "\n")
+    Enum.join([help, type, unit, samples], "\n")
   end
 
   defp format_labels(labels) do

--- a/test/exporter_test.exs
+++ b/test/exporter_test.exs
@@ -8,9 +8,11 @@ defmodule TelemetryMetricsPrometheus.Core.ExporterTest do
       expected = """
       # HELP http_request_total 
       # TYPE http_request_total counter
+      # UNIT http_request_total unit
       http_request_total 1027
       # HELP cache_key_total 
       # TYPE cache_key_total gauge
+      # UNIT cache_key_total unit
       cache_key_total 3
       """
 
@@ -39,6 +41,7 @@ defmodule TelemetryMetricsPrometheus.Core.ExporterTest do
       expected = """
       # HELP http_request_total The total number of HTTP requests.
       # TYPE http_request_total counter
+      # UNIT http_request_total unit
       http_request_total{code="200",method="post"} 1027
       http_request_total{code="400",method="post"} 3\
       """
@@ -63,6 +66,7 @@ defmodule TelemetryMetricsPrometheus.Core.ExporterTest do
       expected = """
       # HELP http_request_total The total number of HTTP requests.
       # TYPE http_request_total counter
+      # UNIT http_request_total unit
       http_request_total 1027\
       """
 
@@ -85,6 +89,7 @@ defmodule TelemetryMetricsPrometheus.Core.ExporterTest do
         ~S(# HELP db_query_total The total number of DB queries. \\\\ \\n) <>
           "\n" <>
           "# TYPE db_query_total counter\n" <>
+          "# UNIT db_query_total unit\n" <>
           ~S(db_query_total{query="SELECT a0.\"id\" FROM \"users\" AS a0 WHERE LIMIT $1"} 1027) <>
           "\n" <>
           ~S(db_query_total{query="\\n \\\\ \""} 4242)
@@ -110,6 +115,7 @@ defmodule TelemetryMetricsPrometheus.Core.ExporterTest do
       expected = """
       # HELP cache_keys_total The total number of cache keys.
       # TYPE cache_keys_total gauge
+      # UNIT cache_keys_total unit
       cache_keys_total{name="users"} 1027
       cache_keys_total{name="short_urls"} 3\
       """
@@ -134,6 +140,7 @@ defmodule TelemetryMetricsPrometheus.Core.ExporterTest do
       expected = """
       # HELP cache_key_total The total number of cache keys.
       # TYPE cache_key_total gauge
+      # UNIT cache_key_total unit
       cache_key_total 1027\
       """
 
@@ -155,6 +162,7 @@ defmodule TelemetryMetricsPrometheus.Core.ExporterTest do
       expected = """
       # HELP cache_key_invalidations_total The total number of cache key invalidations.
       # TYPE cache_key_invalidations_total gauge
+      # UNIT cache_key_invalidations_total unit
       cache_key_invalidations_total{name="users"} 1027
       cache_key_invalidations_total{name="short_urls"} 3\
       """
@@ -180,6 +188,7 @@ defmodule TelemetryMetricsPrometheus.Core.ExporterTest do
       expected = """
       # HELP cache_key_invalidations_total The total number of cache key invalidations.
       # TYPE cache_key_invalidations_total counter
+      # UNIT cache_key_invalidations_total unit
       cache_key_invalidations_total{name="users"} 1027
       cache_key_invalidations_total{name="short_urls"} 3\
       """
@@ -204,6 +213,7 @@ defmodule TelemetryMetricsPrometheus.Core.ExporterTest do
       expected = """
       # HELP cache_key_invalidations_total The total number of cache key invalidations.
       # TYPE cache_key_invalidations_total counter
+      # UNIT cache_key_invalidations_total unit
       cache_key_invalidations_total 1027\
       """
 
@@ -225,6 +235,7 @@ defmodule TelemetryMetricsPrometheus.Core.ExporterTest do
       expected = """
       # HELP http_request_duration_seconds A histogram of the request duration.
       # TYPE http_request_duration_seconds histogram
+      # UNIT http_request_duration_seconds second
       http_request_duration_seconds_bucket{method="GET",le="0.05"} 24054
       http_request_duration_seconds_bucket{method="GET",le="0.1"} 33444
       http_request_duration_seconds_bucket{method="GET",le="0.2"} 100392
@@ -276,6 +287,7 @@ defmodule TelemetryMetricsPrometheus.Core.ExporterTest do
       expected = """
       # HELP http_request_duration_seconds A histogram of the request duration.
       # TYPE http_request_duration_seconds histogram
+      # UNIT http_request_duration_seconds second
       http_request_duration_seconds_bucket{le="0.05"} 24054
       http_request_duration_seconds_bucket{le="0.1"} 33444
       http_request_duration_seconds_bucket{le="0.2"} 100392
@@ -311,6 +323,7 @@ defmodule TelemetryMetricsPrometheus.Core.ExporterTest do
       expected = """
       # HELP foo123_bar_total FOO123 BAR total
       # TYPE foo123_bar_total counter
+      # UNIT foo123_bar_total unit
       foo123_bar_total 1027\
       """
 
@@ -329,6 +342,7 @@ defmodule TelemetryMetricsPrometheus.Core.ExporterTest do
       expected = """
       # HELP foo_bar_total 123FOO BAR total
       # TYPE foo_bar_total counter
+      # UNIT foo_bar_total unit
       foo_bar_total 1027\
       """
 


### PR DESCRIPTION
Per [OpenMetrics spec](https://github.com/prometheus/OpenMetrics/blob/main/specification/OpenMetrics.md#unit), include the `UNIT` line in the exposition from the unit set in the metric.